### PR TITLE
Only build local svn2git if it doesn't exist

### DIFF
--- a/convert-to-git.sh
+++ b/convert-to-git.sh
@@ -20,7 +20,8 @@ svn2git=$(command -v svn-all-fast-export 2>&1)
 if [ ! -f "$svn2git" ]; then
 	svn2git_repo=$current_dir/svn2git
 	svn2git=$svn2git_repo/build/svn-all-fast-export
-
+fi
+if [ ! -f "$svn2git" ]; then
 	# We need qmake, MacPorts has a weird path by default
 	qmake=$(command -v qmake 2>&1)
 	if [ -z "$qmake" ] && [ -f "/opt/local/libexec/qt4/bin/qmake" ]; then


### PR DESCRIPTION
When you committed b4e09c7e2ded5f193de0dc7dc88cd4d8ef27a8d4 you didn't do it the way I had done it in my fork. This pull request reinstates the way I was doing it. Specifically, now a local `svn2git` should only be built if one doesn't already exist. If this isn't necessary or desirable, let me know.
